### PR TITLE
fix: enclose with quotes

### DIFF
--- a/data/apps.csv
+++ b/data/apps.csv
@@ -1342,7 +1342,7 @@ find,rawhide,,https://github.com/raforg/rawhide,File finder that uses C expressi
 utility,sasqwatch,,https://github.com/fabio42/sasqwatch,A modern take on the classic watch command.
 conversion,hecat,,https://gitlab.com/nodiscc/hecat,A generic automation tool around data stored as plain-text YAML files.
 funny,hollywood,,https://github.com/dustinkirkland/hollywood,Runs a script turning your Linux terminal into a Hollywood style real-time hacking terminal.
-funny,bollywood,,https://github.com/dustinkirkland/hollywood,Runs terninal screencasts in multiple panes, resulting in another real-time Hollywood-style real-time hacking terminal.
+funny,bollywood,,https://github.com/dustinkirkland/hollywood,"Runs terninal screencasts in multiple panes, resulting in another real-time Hollywood-style real-time hacking terminal."
 copilot,aider,,https://github.com/paul-gauthier/aider,aider is AI pair programming in your terminal.
 networking,asn,,https://github.com/nitefood/asn,"Server for the following services: ASN, RPKI validity, BGP stats, IPv4v6, Prefix, URL, ASPath, Organization, IP reputation, IP geolocation, IP fingerprinting, Network recon, lookup API server, Web traceroute server."
 viewers,bbcli,,https://github.com/hako/bbcli,Browse BBC News like a hacker.


### PR DESCRIPTION
Enclose line 1345 with quotes to escape comma in description

`We can make this file [beautiful and searchable](https://docs.github.com/articles/rendering-csv-and-tsv-data) if this error is corrected: It looks like row 1345 should actually have 5 columns, instead of 6 in line 1344.`

https://github.com/toolleeo/awesome-cli-apps-in-a-csv/blob/1d6476f14d8791f781d4d6e0864359b3dd714c08/data/apps.csv