### PR TITLE
Add Uni-CLI

### DIFF
--- a/data/apps.csv
+++ b/data/apps.csv
@@ -2227,3 +2227,4 @@ todo-manager,rusk,,https://github.com/tagirov/rusk,A minimal cross-platform term
 file-handling,doxx,,https://github.com/bgreenwell/doxx,"Terminal native document viewer for Word files (view, search and export documents)."
 online,IMDb Terminal Browser,,https://github.com/isene/IMDB,Ruby-based terminal application for discovering and managing movies and TV series from IMDb's Top lists.
 online,Neon Modem Overdrive,,https://github.com/mrusme/neonmodem,The program allows you to manage and read content from various popular platforms without having to use a browser or separate apps.
+ai,Uni-CLI,https://www.npmjs.com/package/@zenalexa/unicli,https://github.com/olo-dot-io/Uni-CLI,"Universal CLI for AI agents with 756 commands across 167 sites (web, desktop, Electron). Self-repairing 20-line YAML adapters, auto-JSON output, ~80 tokens per call. TypeScript, Apache-2.0."


### PR DESCRIPTION
[Uni-CLI](https://github.com/olo-dot-io/Uni-CLI) is a universal CLI for AI agents with 756 commands across 167 sites (web, desktop, Electron). Self-repairing YAML adapters, auto-JSON output, ~80 tokens per call. TypeScript, Apache-2.0.

Added to the `ai` category in `data/apps.csv`.