### PR TITLE
Add scope - neofetch for your codebase

### DIFF
--- a/data/apps.csv
+++ b/data/apps.csv
@@ -2229,3 +2229,4 @@ file-handling,doxx,,https://github.com/bgreenwell/doxx,"Terminal native document
 online,IMDb Terminal Browser,,https://github.com/isene/IMDB,Ruby-based terminal application for discovering and managing movies and TV series from IMDb's Top lists.
 online,Neon Modem Overdrive,,https://github.com/mrusme/neonmodem,The program allows you to manage and read content from various popular platforms without having to use a browser or separate apps.
 cheatsheet,mdpick,,https://github.com/toolleeo/mdpick,"A terminal user interface (TUI) tool for interactively selecting and extracting code blocks or links from Markdown files and copy them to the clipboard, ready for being pasted right in the command line or anywhere else, or a tmux pane."
+programming,scope,,https://github.com/AZERDSQ131/scope,"Neofetch for your codebase: instant project overview with tech stack, git history, file structure, and dependencies."


### PR DESCRIPTION
Adds [scope](https://github.com/AZERDSQ131/scope) to the programming section. Scope is a CLI tool that gives you an instant overview of any codebase - tech stack, git history, file structure, and dependencies. Like neofetch for your projects.