### PR TITLE
Add DocRefract

### DIFF
--- a/data/apps.csv
+++ b/data/apps.csv
@@ -2206,3 +2206,4 @@ online,Neon Modem Overdrive,,https://github.com/mrusme/neonmodem,The program all
 cheatsheet,mdpick,,https://github.com/toolleeo/mdpick,"A terminal user interface (TUI) tool for interactively selecting and extracting code blocks or links from Markdown files and copy them to the clipboard, ready for being pasted right in the command line or anywhere else, or a tmux pane."
 learning,bashquest,,https://github.com/toolleeo/bashquest,Shell quest (Capture-The-Flag-style): a didactic game to train/teach common Unix shell commands.
 games,cli.poker,https://www.cli.poker,,Multiplayer Texas Hold'em poker played in the terminal over SSH. Just run `ssh cli.poker`.
+diff,DocRefract,https://jinyounghub.github.io/docrefract/,https://github.com/jinyounghub/docrefract.git,Local-first deterministic semantic PDF and DOCX comparison for CI with categorized JSON and self-contained HTML reports.


### PR DESCRIPTION
## What changed

- Added DocRefract to `data/apps.csv` in the `diff` category.
- Included its project homepage and clonable Git repository URL.

## Why

DocRefract is a local-first CLI for deterministic semantic PDF and DOCX comparison in CI. It produces categorized JSON and self-contained HTML reports.

## Impact

CLI users looking for document regression and diff tools can discover DocRefract in the generated list.

## Validation

- `python -X utf8 cli2md.py`
- Parsed all 2,232 CSV rows and confirmed the DocRefract name, homepage, and Git URL are unique.
- Confirmed `git diff --check` passes.
- Confirmed the homepage returns HTTP 200 and the Git URL is clonable.
